### PR TITLE
Add project grouper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ Source for https://phabricator.wikimedia.org/p/Maintenance_bot/
 Report issues and bugs: https://phabricator.wikimedia.org/project/board/5124/
 
 * `column_mover.py` is a script that can move columns of a task when some actions happens on it. E.g. Moving a task in workboard #user-ladsgroup from column "incoming" to column "done" when someone changes the task's status to "done"
+* `project_grouper.py` adds tasks in configured projects to other configured projects
 * `patchforreview_remover.py` is an automatic script that removes the "patch_for_review" tag when all patches have been merged or abandoned

--- a/cron
+++ b/cron
@@ -1,4 +1,5 @@
 15 * * * * jsub -once -N column_mover python3 /data/project/phabbot/phabbot/column_mover.py /data/project/phabbot/phabbot/creds.json 3600 >/dev/null 2>&1
+45 * * * * jsub -once -N column_mover python3 /data/project/phabbot/phabbot/project_grouper.py /data/project/phabbot/phabbot/creds.json 3600 >/dev/null 2>&1
 10 * * * * jsub -once -N patch_for_review python3 /data/project/phabbot/phabbot/patchforreview_remover.py /data/project/phabbot/phabbot/creds.json 3600 >/dev/null 2>&1
 5 * * * * jlocal bash /data/project/phabbot/phabbot/updater.sh >/dev/null 2>&1
 10 22,4,10,16 * * * jsub -once -N new_wikis_handler bash /data/project/phabbot/phabbot/new_wikis_handler.sh >/dev/null 2>&1

--- a/lib.py
+++ b/lib.py
@@ -71,6 +71,15 @@ class Client(object):
             }]
         })
 
+    def addTaskProject(self, task_phid, project_phid):
+        self.post('maniphest.edit', {
+            'objectIdentifier': task_phid,
+            'transactions': [{
+                'type': 'projects.add',
+                'value': [project_phid],
+            }]
+        })
+
     def createSubtask(self, desc, project_phids, parent_phid, title):
         self.post('maniphest.edit', {
             'objectIdentifier': '',

--- a/project_grouper.py
+++ b/project_grouper.py
@@ -1,0 +1,31 @@
+"""
+Adds tasks in configured projects to other configured projects
+"""
+
+from lib import Client
+
+rules = [
+    {
+        # current H175 - see T136921
+        'add': 'Design',
+        'in': ['WMF-Design', 'WMDE-Design'],
+    },
+]
+
+client = Client.newFromCreds()
+
+for rule in rules:
+    handled_tasks = []
+
+    wanted_project_phid = client.lookupPhid('#' + rule['add'])
+    for project_name in rule['in']:
+        project_phid = client.lookupPhid('#' + project_name)
+        for task_phid in client.getTasksWithProject(project_phid):
+            # if a task is in multiple 'in' projects, still only process it once
+            if task_phid in handled_tasks:
+                continue
+            handled_tasks.append(task_phid)
+
+            task = client.taskDetails(task_phid)
+            if wanted_project_phid not in task['projectPHIDs']:
+                client.addTaskProject(task_phid, wanted_project_phid)


### PR DESCRIPTION
Add task grouper, which can replace some expensive global Herald rules, in this case group 5 in Danny's comment https://phabricator.wikimedia.org/T108586#5669368﻿. Group 4 could be also implemented with some database help, but I'll do that as a follow-up if wanted.

If this is merged, someone needs to add rules other than H175 (which I used for testing) to the config array and disable those rules on Phabricator. Tasks that aren't visible to the bot can't be moved from Herald to a bot (the first examples that come to mind are procurement and security)