### PR TITLE
Add remaining group 5 Herald rules to config

### DIFF
--- a/cron
+++ b/cron
@@ -1,5 +1,5 @@
 15 * * * * jsub -once -N column_mover python3 /data/project/phabbot/phabbot/column_mover.py /data/project/phabbot/phabbot/creds.json 3600 >/dev/null 2>&1
-45 * * * * jsub -once -N column_mover python3 /data/project/phabbot/phabbot/project_grouper.py /data/project/phabbot/phabbot/creds.json 3600 >/dev/null 2>&1
+45 * * * * jsub -once -N project_grouper python3 /data/project/phabbot/phabbot/project_grouper.py /data/project/phabbot/phabbot/creds.json 3600 >/dev/null 2>&1
 10 * * * * jsub -once -N patch_for_review python3 /data/project/phabbot/phabbot/patchforreview_remover.py /data/project/phabbot/phabbot/creds.json 3600 >/dev/null 2>&1
 5 * * * * jlocal bash /data/project/phabbot/phabbot/updater.sh >/dev/null 2>&1
 10 22,4,10,16 * * * jsub -once -N new_wikis_handler bash /data/project/phabbot/phabbot/new_wikis_handler.sh >/dev/null 2>&1

--- a/project_grouper.py
+++ b/project_grouper.py
@@ -6,10 +6,106 @@ from lib import Client
 
 rules = [
     {
-        # current H175 - see T136921
+        # H175 - see T136921
         'add': 'Design',
         'in': ['WMF-Design', 'WMDE-Design'],
     },
+    {
+        # H232
+        'add': 'artificial-intelligence',
+        'in': ['editquality-modeling', 'draftquality-modeling', 'articlequality-modeling', 'revscoring'],
+    },
+    {
+        # H193 - see T146701
+        'add': 'accessibility',
+        'in': ['ios-app-feature-accessibility'],
+    },
+    {
+        # H174
+        'add': 'upstream',
+        'in': ['phabricator-upstream'],
+    },
+    {
+        # H24 - see T86536
+        'add': 'universallanguageselector',
+        'in': ['uls-compactlinks'],
+    },
+    {
+        # H15 - note that #producrement tasks are private -> rule can't be disabled
+        'add': 'Operations',
+        'in': [
+            'ops-eqiad',
+            'ops-codfw',
+            'ops-esams',
+            'ops-ulsfo',
+            # 'hardware-requests', archived project
+            'SRE-Access-Requests',
+            'netops',
+            'vm-requests',
+            'Traffic',
+            'ops-eqord',
+            'ops-eqdfw',
+            # 'procurement', always in S4
+            'ops-eqsin',
+            'DNS',
+            'LDAP-Access-Requests',
+            'Wikimedia-Mailing-lists',
+        ],
+    },
+    {
+        # H14 - see T85596
+        'add': 'Social-Tools',
+        'in': [
+            'BlogPage',
+            'Comments',
+            'FanBoxes',
+            'LinkFilter',
+            'PollNY',
+            'QuizGame',
+            # 'RandomFeaturedUser', archived project
+            'RandomGameUnit',
+            'SocialProfile',
+            'SiteMetrics',
+            'VoteNY',
+            'WikiForum',
+            'WikiTextLoggedInOut',
+            'Challenge',
+            'MiniInvite',
+            # 'NewUsersList', archived project
+            'PictureGame',
+            # 'RandomUsersWithAvatars', archived project
+            'Video (non-WMF)',
+            # 'TopLists', archived project
+        ],
+    },
+    {
+        # H10 - see T76954
+        'add': 'VisualEditor',
+        'in': [
+            'VisualEditor-ContentEditable',
+            'VisualEditor-ContentLanguage',
+            'VisualEditor-CopyPaste',
+            'VisualEditor-DataModel',
+            'VisualEditor-EditingTools',
+            'VisualEditor-Initialisation',
+            'VisualEditor-InterfaceLanguage',
+            'VisualEditor-MediaWiki',
+            'VisualEditor-MediaWiki-Links',
+            'VisualEditor-MediaWiki-Media',
+            'VisualEditor-MediaWiki-Mobile',
+            'VisualEditor-MediaWiki-References',
+            'VisualEditor-MediaWiki-Templates',
+            'VisualEditor-Performance',
+            'VisualEditor-Tables',
+            'TemplateData',
+            'VisualEditor-MediaWiki-Plugins',
+            'VisualEditor-LanguageTool',
+            'VisualEditor-Links',
+            'VisualEditor-Media',
+            'VisualEditor-MediaWiki-2017WikitextEditor',
+            'VisualEditor-VisualDiffs',
+        ],
+    }
 ]
 
 client = Client.newFromCreds()

--- a/project_grouper.py
+++ b/project_grouper.py
@@ -74,7 +74,7 @@ rules = [
             # 'NewUsersList', archived project
             'PictureGame',
             # 'RandomUsersWithAvatars', archived project
-            'Video (non-WMF)',
+            'video_non-wmf',
             # 'TopLists', archived project
         ],
     },


### PR DESCRIPTION
Please disable following Herald rules after merging:
* H232
* H193
* H174
* H24
* H15 -- note! this is still needed for Procurement things, so remove everything else but leave that
* H14
* H10