### PR TITLE
project_grouper: [Wikidata] Remove Wikidata-Page-Banner

### DIFF
--- a/project_grouper.py
+++ b/project_grouper.py
@@ -120,7 +120,6 @@ rules = [
         # H30
         'add': 'wikidata',
         'in': [
-            'Wikidata-Page-Banner',
             'Wikibase-Quality-Constraints',
             'DataValues',
             'DataValues-JavaScript',


### PR DESCRIPTION
WikidataPageBanner is a Wikivoyage extension that isn’t maintained by the Wikidata team; I don’t think it makes sense to automatically add Wikidata to all its tasks (e.g. [T323376](https://phabricator.wikimedia.org/T323376)).

@Ladsgroup @lydiapintscher WDYT?