### PR TITLE
new_wikis_handler: Write Cirrus maint script output to log file

### DIFF
--- a/new_wikis_handler.py
+++ b/new_wikis_handler.py
@@ -460,9 +460,10 @@ def add_create_instructions(parts, shard, language_code, db_name, task_tid):
         add_text(sync_file('langlist', summary))
 
     add_text('On mwmaint1002:')
-    add_text('`{search_path} --wiki={dbname} --cluster=all`'.format(
+    add_text('`{search_path} --wiki={dbname} --cluster=all 2>&1 | tee {log}`'.format(
         search_path='mwscript extensions/CirrusSearch/maintenance/UpdateSearchIndexConfig.php',
         dbname=db_name,
+        log='/tmp/{dbname}.UpdateSearchIndexConfig.log'.format(dbname=db_name),
     ))
 
     add_text('On deployment host:')


### PR DESCRIPTION
This script hasn't been working as expected lately, search indices are not being created for the new wikis. Adding a bit to the command to log the output into a file so it can be reviewed for errors post-creation.