### PR TITLE
new_wikis_handler: Modify wording about bot policy

### DIFF
--- a/new_wikis_handler.py
+++ b/new_wikis_handler.py
@@ -71,7 +71,7 @@ class PostCreationHandler(object):
             checker()
         self.add_text(' [] Import from Incubator')
         self.add_text(' [] Clean up old interwiki links')
-        self.add_text(' [] Propose the implementation of the standard bot policy')
+        self.add_text(' [] For content wikis (not private, fishbowl, special, etc.) [[ https://meta.wikimedia.org/wiki/Stewards%27_noticeboard | Ask the stewards ]] to add the wiki to the [[ https://meta.wikimedia.org/wiki/Bot_policy| Bot policy ]] wikiset')
         self.add_text(' [] Inform the [[ https://meta.wikimedia.org/wiki/Talk:Countervandalism_Network | CVN ]] project for IRC monitoring')
 
         self._create_ticket()


### PR DESCRIPTION
See [current policy wording](https://meta.wikimedia.org/w/index.php?oldid=24449416#Global_bots) as per [this RfC](https://meta.wikimedia.org/wiki/Requests_for_comment/Make_all_new_wikis_global_bot_wikis). BP is automatically enabled on all content wikis by default so there's no need to propose its implementation. Rather, we need to notify them that we've added the wiki to the wikiset and if they wish to opt-out, they shall have a local discussion and let us know. This should make it clearer but I'm open to suggestions.